### PR TITLE
fix: fix yellow magnesium regression

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,11 +21,11 @@
   ],
   "content_scripts": [{
     "matches": ["http://*/*", "https://*/*"],
-    "js": ["content.ts"],
+    "js": ["content.js"],
     "run_at": "document_idle"
   }],
   "web_accessible_resources": [{
-    "resources": ["content.ts"],
+    "resources": ["content.js"],
     "matches": ["http://*/*", "https://*/*"]
   }],
   "background": {


### PR DESCRIPTION
some weird occurence here between https://github.com/GangGreenTemperTatum/DOMspy/pull/12 & https://github.com/GangGreenTemperTatum/DOMspy/pull/10 (can see merge [conflicts](https://github.com/GangGreenTemperTatum/DOMspy/pull/10/conflicts) in the PR rn)

addresses load unpacked error into chrome extensions:

```html

Violation reference ID: Yellow MagnesiumViolation: Not providing promised functionalityUnable to install the package error in the manifest file ,it could not load javascript 'content.ts' for the script.How to rectify: Test the code that you submit to the web store locally, verify that your submission contains the files you expect at the paths you expect, and is working as intended. For more information, please refer to the documentation and migration checklist on Manifest V3 version.Relevant section of the program policy: Extensions with broken functionality - such as dead sites or non-functioning features - are not allowed.
--


Violation reference ID: [Yellow Magnesium](https://developer.chrome.com/docs/webstore/troubleshooting/#does-not-work)
Violation: Not providing promised functionality
Unable to install the package error in the manifest file ,it could not load javascript 'content.ts' for the script.
How to rectify: Test the code that you submit to the web store locally, verify that your submission contains the files you expect at the paths you expect, and is working as intended. For more information, please refer to the [documentation](https://developer.chrome.com/docs/extensions/mv3/intro/) and migration [checklist](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/) on Manifest V3 version.
Relevant section of the program policy: Extensions with broken functionality - such as dead sites or non-functioning features - are not allowed.
```